### PR TITLE
fix: Include icns.json file in package, fixes #48

### DIFF
--- a/.changes/include-json.md
+++ b/.changes/include-json.md
@@ -1,0 +1,5 @@
+---
+"tauricon": patch
+---
+
+Include icns.json file in generated package.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "files": [
     "bin",
     "dist",
-    "scripts"
+    "scripts",
+    "src/helpers/icns.json"
   ],
   "scripts": {
     "postinstall": "",


### PR DESCRIPTION
alternatively, we could add a rollup plugin, but imo that's not worth it for this simple case.